### PR TITLE
fix: Jest no tests found

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
       "<rootDir>/scripts/enzymeConfig.js"
     ],
     "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
+      "**/__tests__/**/*.[jt]s?(x)",
+      "**/?(*.)+(spec|test).[jt]s?(x)"
     ],
     "testEnvironment": "jsdom",
     "testURL": "http://localhost",


### PR DESCRIPTION
Basically I reverted the `testMatch` property to reflect the [default one for Jest 24.1](https://jestjs.io/docs/en/configuration#testmatch-array-string). Seems to fix it for me. I could also just delete the `testMatch` property but decided to keep it explicit for clarity. If you want I can just delete it.